### PR TITLE
terraform: fix password generation

### DIFF
--- a/terraform/test-server.tf
+++ b/terraform/test-server.tf
@@ -94,7 +94,14 @@ resource "azurerm_key_vault_access_policy" "kvap-sshizzle-test-server" {
 // Generate a random password for the VM
 resource "random_password" "vm-password" {
   length           = 20
+  lower            = true
+  min_lower        = 1
+  upper            = true
+  min_upper        = 1
+  number           = true
+  min_numeric      = 1
   special          = true
+  min_special      = 1
   override_special = "_%@"
 }
 


### PR DESCRIPTION
During the test-server deployment a VM is generated.
The password of stated VM needs to fullfill the following
requirements enforced by Azure:

- At least one numeric value.
- At least one lower case character.
- At least one upper case character.
- At least one special character.

Fixes #2 