### PR TITLE
Configurable key size for CA

### DIFF
--- a/terraform/sshizzle.tf
+++ b/terraform/sshizzle.tf
@@ -45,12 +45,12 @@ resource "azurerm_key_vault" "kv-sshizzle" {
   }
 }
 
-// Create the CA key - an Azure generated 2048 bit RSA key
+// Create the CA key - an Azure generated RSA key
 resource "azurerm_key_vault_key" "key-sshizzle" {
   name         = "sshizzle"
   key_vault_id = azurerm_key_vault.kv-sshizzle.id
   key_type     = "RSA"
-  key_size     = 2048
+  key_size     = "${var.ca_key_size}"
   key_opts     = ["sign", "verify"]
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,3 +12,9 @@ variable "prefix" {
   type         = string
   description  = "Azure name prefix"
 }
+
+variable "ca_key_size" {
+  type        = number
+  description = "Size in bits of the RSA CA key (2048, 3072, or 4096)"
+  default     = 4096
+}


### PR DESCRIPTION
This addresses the first point of #10 by making the size of the CA private key (a RSA key) configurable, with a default of 4096 bits. The default is increased from the old 2048 bits, as it's perhaps a better default for a CA key.

This PR does not alter the keys that nodes use to authenticate with SSH. Those remain 2048-bit RSA keys, and they're currently not configurable. In #10 there's an open conversation on whether those should be made configurable, and perhaps adding support for EC keys.